### PR TITLE
Add storm-day filter, KML export, and AWS Batch deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Detect tornado-driven ground change from Sentinel imagery, score the severity, a
 - Build median pre/post mosaics and compute a composite change score using vegetation loss, brightness increase, and SAR backscatter change.
 - Threshold the change map, filter polygons by elongation, and assign a Ground-Scour Score (GSS 0–5).
 - Export GeoTIFF rasters, GeoJSON polygons, and a ready-to-host Leaflet map under `docs/` for GitHub Pages.
+- Emit a Google Earth-ready KML file alongside the GeoJSON export for quick sharing.
 - Continuous integration workflow that runs the pipeline and publishes run artifacts on every push.
 
 ## Quick start
@@ -37,9 +38,41 @@ See `data/config.yaml` for the default options:
 - **Elongation filter**: Enable to keep polygons aligned with an expected tornado-track bearing and an elongation ratio ≥ 2.0. Optional keys `elongation_tolerance_deg` and `elongation_min_ratio` further tune the filter.
 - **GSS breaks**: Either `"quantile"` (default quintiles) or an explicit list of five monotonically increasing thresholds.
 - **Web map**: Customize the title, description, and initial map viewpoint.
+- **Storm filter**: Optionally gate the entire run on a catalog of historical storm reports. Provide a CSV file with at least
+  the event timestamp, hazard type, and coordinates. When enabled, the pipeline loads the catalog, keeps events that intersect
+  the AOI (with an optional distance buffer) within the specified post-event window, exports them to GeoJSON, and aborts early
+  when no qualifying storm days are found.
+
+### Storm-filter workflow
+
+The `storm_filter` block in `data/config.yaml` demonstrates the expected schema:
+
+```yaml
+storm_filter:
+  enabled: true
+  catalog: data/storm_reports_example.csv
+  datetime_column: event_time_utc
+  hazard_column: hazard
+  latitude_column: latitude
+  longitude_column: longitude
+  hazards: [Tornado]
+  distance_km: 50
+  days_before: 0
+  days_after: 1
+  export_geojson: docs/data/storm_events.geojson
+```
+
+Populate the catalog with historical or forecast storm-day observations. When the post-analysis window (plus optional lead/lag
+days) contains at least one entry that falls within the AOI buffer, the full Sentinel processing pipeline runs and writes both
+GeoJSON (`docs/data/changes.geojson`) and KML (`docs/data/changes.kml`) outputs. If no storm events are found, the command
+skips the expensive remote sensing steps, clears previous change layers by writing empty GeoJSON/KML stubs, and exits with a
+message indicating that no storm day was detected.
 
 ## GitHub Pages workflow
 The Leaflet app is designed to live under `docs/`. Enable Pages for the repository and target the `docs/` folder to publish the latest change polygons.
+
+## Running on AWS
+For an opinionated example that packages the pipeline into a container image and runs it on AWS Batch with S3-backed inputs/outputs, see [`infra/aws-batch-example`](infra/aws-batch-example/README.md). The walkthrough covers building and pushing the image to ECR, wiring Batch compute environments and job definitions, and triggering jobs automatically on storm days with EventBridge.
 
 ## Tuning tips
 - Tighten the pre/post acquisition windows around the event to avoid seasonal noise.

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -22,3 +22,16 @@ web:
   description: "Auto-built from Sentinel pre/post windows."
   center: [-27.0, 151.5]
   zoom: 9
+storm_filter:
+  enabled: true
+  catalog: data/storm_reports_example.csv
+  datetime_column: event_time_utc
+  hazard_column: hazard
+  latitude_column: latitude
+  longitude_column: longitude
+  hazards:
+    - Tornado
+  distance_km: 50
+  days_before: 0
+  days_after: 1
+  export_geojson: docs/data/storm_events.geojson

--- a/data/storm_reports_example.csv
+++ b/data/storm_reports_example.csv
@@ -1,0 +1,4 @@
+event_time_utc,hazard,latitude,longitude,details
+2023-04-19T22:30:00Z,Tornado,35.223,-97.445,EF2 tornado near Norman, OK
+2023-04-19T23:45:00Z,Hail,35.310,-97.210,Large hail reports south of Oklahoma City
+2023-04-20T01:05:00Z,Tornado,35.430,-97.150,Brief touchdown east of Moore, OK

--- a/infra/aws-batch-example/Dockerfile
+++ b/infra/aws-batch-example/Dockerfile
@@ -1,0 +1,22 @@
+# Example container for running the tornado ground-scoring pipeline on AWS Batch.
+# Build with: docker build -f infra/aws-batch-example/Dockerfile .
+
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.3
+
+WORKDIR /workspace
+
+# Install Python dependencies and AWS CLI.
+COPY requirements.txt ./
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --no-cache-dir -r requirements.txt awscli
+
+# Copy the project code into the image.
+COPY src ./src
+COPY data ./data
+COPY docs ./docs
+COPY infra/aws-batch-example/entrypoint.sh ./infra/aws-batch-example/entrypoint.sh
+COPY README.md ./README.md
+
+ENV PYTHONPATH=/workspace
+
+ENTRYPOINT ["/workspace/infra/aws-batch-example/entrypoint.sh"]

--- a/infra/aws-batch-example/README.md
+++ b/infra/aws-batch-example/README.md
@@ -1,0 +1,155 @@
+# AWS Batch deployment example
+
+This directory provides a minimal example of how to run the tornado ground scoring
+pipeline on [AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html).
+It uses a container image that downloads a configuration file from Amazon S3,
+executes `python -m src.run_pipeline`, and then pushes the rendered outputs back to S3.
+
+## Architecture overview
+
+1. **Amazon S3** stores configuration files, AOI GeoJSON, and the pipeline outputs.
+2. **Amazon Elastic Container Registry (ECR)** hosts the container image built from
+   `Dockerfile` in this directory.
+3. **AWS Batch** runs the container image on a compute environment (Fargate or EC2).
+4. **Amazon EventBridge** (optional) triggers the Batch job on storm days, for example
+   by reacting to a daily schedule or NOAA event feed.
+
+## Build and publish the container image
+
+```bash
+# From the repository root
+aws ecr create-repository --repository-name tornado-ground-scoring
+ECR_URI=$(aws ecr describe-repositories \
+  --repository-names tornado-ground-scoring \
+  --query 'repositories[0].repositoryUri' --output text)
+
+aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_URI"
+
+docker build -f infra/aws-batch-example/Dockerfile -t tornado-ground-scoring:latest .
+docker tag tornado-ground-scoring:latest "$ECR_URI:latest"
+docker push "$ECR_URI:latest"
+```
+
+## Prepare S3 inputs
+
+Upload your configuration YAML (and any referenced AOI or storm catalog files) to S3:
+
+```bash
+aws s3 cp data/config.yaml s3://my-bucket/configs/tornado-config.yaml
+aws s3 cp data/storm_reports_example.csv s3://my-bucket/configs/storm_reports_example.csv
+aws s3 cp data/example_aoi.geojson s3://my-bucket/configs/example_aoi.geojson
+```
+
+Update the S3 URIs inside the uploaded `config.yaml` so that file paths point to the
+objects you just uploaded.
+
+## Create the Batch job definition
+
+Edit `job-definition.json` and replace the account IDs, role ARNs, and S3 bucket names
+with your own. Then register the job definition:
+
+```bash
+aws batch register-job-definition \
+  --cli-input-json file://infra/aws-batch-example/job-definition.json
+```
+
+You also need a compute environment and job queue. A minimal Fargate setup can be
+created with:
+
+```bash
+aws batch create-compute-environment \
+  --compute-environment-name tornado-ce \
+  --type MANAGED \
+  --state ENABLED \
+  --compute-resources '{
+    "type": "FARGATE",
+    "maxvCpus": 32,
+    "subnets": ["subnet-abc123"],
+    "securityGroupIds": ["sg-abc123"]
+  }'
+
+aws batch create-job-queue \
+  --job-queue-name tornado-queue \
+  --priority 1 \
+  --compute-environment-order '[{"order":1,"computeEnvironment":"tornado-ce"}]'
+```
+
+Finally, submit a test job:
+
+```bash
+aws batch submit-job \
+  --job-name tornado-ground-scoring-test \
+  --job-queue tornado-queue \
+  --job-definition tornado-ground-scoring
+```
+
+The container downloads the config from `CONFIG_S3_URI`, runs the pipeline, and
+synchronizes `docs/` and `artifacts/` back to `EXPORT_S3_PREFIX`.
+
+## Automate with EventBridge (optional)
+
+Create a rule that triggers only on storm days. For example, use a daily cron rule
+that invokes a Lambda function. The Lambda can inspect the National Weather Service
+storm reports API, and when a qualifying storm is detected, submit the Batch job via
+`aws batch submit-job`.
+
+```python
+import json
+import os
+
+import boto3
+import requests
+
+BATCH_QUEUE = os.environ["BATCH_QUEUE"]
+BATCH_JOB_DEFINITION = os.environ["BATCH_JOB_DEFINITION"]
+STORM_API = "https://api.weather.gov/alerts/active?event=Tornado%20Warning"
+
+batch = boto3.client("batch")
+
+
+def handler(event, context):
+    response = requests.get(STORM_API, timeout=10)
+    response.raise_for_status()
+    alerts = response.json().get("features", [])
+    if not alerts:
+        return {"triggered": False}
+
+    batch.submit_job(
+        jobName="tornado-ground-scoring-auto",
+        jobQueue=BATCH_QUEUE,
+        jobDefinition=BATCH_JOB_DEFINITION,
+    )
+    return {"triggered": True, "alerts": len(alerts)}
+```
+
+Use the Lambda to set `CONFIG_S3_URI` dynamically if you maintain per-day
+configuration files.
+
+## IAM considerations
+
+Grant the Batch job role permission to:
+
+- `s3:GetObject` for the configuration bucket/prefix.
+- `s3:PutObject` and `s3:DeleteObject` for the output prefix.
+- `logs:CreateLogStream` and `logs:PutLogEvents` for Amazon CloudWatch Logs.
+
+The execution role should allow pulling the ECR image and writing logs.
+
+## Cost controls
+
+- Use Spot Fargate or EC2 Spot instances to reduce compute cost.
+- Restrict EventBridge rules so that only storm-qualifying days trigger jobs.
+- Lifecycle policies on the S3 output bucket to expire stale artifacts.
+
+## Environment variables
+
+The container entrypoint recognises the following environment variables:
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `CONFIG_S3_URI` | Yes | `s3://` URI of the main pipeline config file. |
+| `EXTRA_CONFIG_S3_URI` | No | `s3://` prefix that will be recursively copied into the container before execution (for AOIs, storm catalogs, etc.). |
+| `EXPORT_S3_PREFIX` | No | `s3://` prefix to which `docs/` and `artifacts/` are synced after the run. |
+| `EXPORT_CSV_PATH` | No | Local path (inside the container) where the optional CSV export should be written; combine with `EXPORT_S3_PREFIX` to sync it out. |
+
+Adjust the job definition to set these variables for each run.

--- a/infra/aws-batch-example/entrypoint.sh
+++ b/infra/aws-batch-example/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${CONFIG_S3_URI:-}" ]]; then
+  echo "CONFIG_S3_URI environment variable must be set to an s3:// URI" >&2
+  exit 1
+fi
+
+WORKDIR="/workspace"
+CONFIG_PATH="$WORKDIR/config.yaml"
+
+mkdir -p "$WORKDIR/artifacts" "$WORKDIR/docs"
+
+aws s3 cp "$CONFIG_S3_URI" "$CONFIG_PATH"
+
+if [[ -n "${EXTRA_CONFIG_S3_URI:-}" ]]; then
+  aws s3 cp "$EXTRA_CONFIG_S3_URI" "$WORKDIR/" --recursive
+fi
+
+python3 -m src.run_pipeline --config "$CONFIG_PATH" ${EXPORT_CSV_PATH:+--export-csv "$EXPORT_CSV_PATH"}
+
+if [[ -n "${EXPORT_S3_PREFIX:-}" ]]; then
+  aws s3 sync "$WORKDIR/docs" "${EXPORT_S3_PREFIX%/}/docs" --delete
+  aws s3 sync "$WORKDIR/artifacts" "${EXPORT_S3_PREFIX%/}/artifacts" --delete
+fi

--- a/infra/aws-batch-example/job-definition.json
+++ b/infra/aws-batch-example/job-definition.json
@@ -1,0 +1,22 @@
+{
+  "jobDefinitionName": "tornado-ground-scoring",
+  "type": "container",
+  "platformCapabilities": ["FARGATE"],
+  "containerProperties": {
+    "image": "${ECR_REPOSITORY_URI}:latest",
+    "command": [],
+    "executionRoleArn": "arn:aws:iam::123456789012:role/BatchExecutionRole",
+    "jobRoleArn": "arn:aws:iam::123456789012:role/BatchJobRole",
+    "resourceRequirements": [
+      { "type": "VCPU", "value": "4" },
+      { "type": "MEMORY", "value": "16000" }
+    ],
+    "environment": [
+      { "name": "CONFIG_S3_URI", "value": "s3://my-bucket/configs/tornado-config.yaml" },
+      { "name": "EXPORT_S3_PREFIX", "value": "s3://my-bucket/outputs/tornado" }
+    ]
+  },
+  "retryStrategy": {
+    "attempts": 1
+  }
+}

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
 
 import click
 import geopandas as gpd
@@ -14,7 +17,7 @@ import yaml
 from rasterio import features
 from shapely.geometry import mapping
 
-from . import change_core, fetch_stack, gss
+from . import change_core, fetch_stack, gss, storm_filter
 from .aoi_utils import load_aoi
 
 LOGGER = logging.getLogger(__name__)
@@ -34,6 +37,46 @@ def main(config_path: str, export_csv: Optional[str]) -> None:
 
     aoi = load_aoi(cfg["aoi_geojson"])
     catalogs = cfg.get("stac_catalogs", [])
+
+    post_from = _parse_date(cfg["post_from"])
+    post_to = _parse_date(cfg["post_to"])
+
+    storm_cfg = cfg.get("storm_filter", {})
+    if storm_cfg.get("enabled"):
+        if "catalog" not in storm_cfg:
+            raise KeyError("storm_filter.catalog must be provided when enabled")
+        schema = storm_filter.CatalogSchema(
+            datetime_column=storm_cfg.get("datetime_column", "event_time_utc"),
+            hazard_column=storm_cfg.get("hazard_column", "hazard"),
+            latitude_column=storm_cfg.get("latitude_column", "latitude"),
+            longitude_column=storm_cfg.get("longitude_column", "longitude"),
+        )
+        catalog = storm_filter.load_catalog(Path(storm_cfg["catalog"]), schema)
+        events = storm_filter.relevant_events(
+            catalog=catalog,
+            aoi=aoi,
+            window_start=post_from,
+            window_end=post_to,
+            hazards=storm_cfg.get("hazards"),
+            days_before=int(storm_cfg.get("days_before", 0)),
+            days_after=int(storm_cfg.get("days_after", 0)),
+            distance_km=float(storm_cfg.get("distance_km", 0.0)),
+        )
+        export_path = storm_cfg.get("export_geojson")
+        if export_path:
+            storm_filter.export_events(events, Path(export_path))
+        if events.empty:
+            LOGGER.info(
+                "Storm filter found no qualifying events between %s and %s; skipping",
+                post_from,
+                post_to,
+            )
+            _write_empty_outputs(
+                Path("docs/data/changes.geojson"), Path("docs/data/changes.kml")
+            )
+            click.echo("No storm events in window; outputs cleared.")
+            return
+        LOGGER.info("Storm filter retained %s events", len(events))
 
     pre_items = fetch_stack.search_sentinel2(aoi, cfg["pre_from"], cfg["pre_to"], catalogs)
     post_items = fetch_stack.search_sentinel2(aoi, cfg["post_from"], cfg["post_to"], catalogs)
@@ -98,6 +141,7 @@ def main(config_path: str, export_csv: Optional[str]) -> None:
     geojson_path = Path("docs/data/changes.geojson")
     _ensure_directory(geojson_path.parent)
     _write_geojson(polygons, geojson_path)
+    _write_kml(polygons, Path("docs/data/changes.kml"))
 
     if export_csv and not polygons.empty:
         _ensure_directory(Path(export_csv).parent or Path("."))
@@ -159,6 +203,97 @@ def _write_geojson(polygons: gpd.GeoDataFrame, path: Path) -> None:
     with path.open("w", encoding="utf-8") as f:
         json.dump(collection, f)
     LOGGER.info("Wrote %s", path)
+
+
+def _write_kml(polygons: gpd.GeoDataFrame, path: Path) -> None:
+    colors = {
+        0: "#f7fbff",
+        1: "#c6dbef",
+        2: "#9ecae1",
+        3: "#6baed6",
+        4: "#3182bd",
+        5: "#08519c",
+    }
+
+    kml = ET.Element("kml", xmlns="http://www.opengis.net/kml/2.2")
+    document = ET.SubElement(kml, "Document")
+    ET.SubElement(document, "name").text = "Ground Scour Change"
+
+    for gss_value, hex_color in colors.items():
+        style = ET.SubElement(document, "Style", id=f"gss-{gss_value}")
+        line_style = ET.SubElement(style, "LineStyle")
+        ET.SubElement(line_style, "color").text = "ff333333"
+        ET.SubElement(line_style, "width").text = "1"
+        poly_style = ET.SubElement(style, "PolyStyle")
+        ET.SubElement(poly_style, "color").text = _hex_to_kml_color(hex_color, 0.6)
+        ET.SubElement(poly_style, "outline").text = "1"
+
+    if not polygons.empty:
+        polygons_wgs84 = polygons.to_crs(4326)
+        for _, row in polygons_wgs84.iterrows():
+            placemark = ET.SubElement(document, "Placemark")
+            gss_value = int(row.get("gss", 0))
+            ET.SubElement(placemark, "name").text = f"GSS {gss_value}"
+            description_parts = []
+            if "mean_score" in row:
+                description_parts.append(f"Mean score: {row['mean_score']:.3f}")
+            if "max_score" in row:
+                description_parts.append(f"Max score: {row['max_score']:.3f}")
+            if "area_m2" in row:
+                description_parts.append(f"Area (ha): {row['area_m2'] / 10000:.2f}")
+            if description_parts:
+                ET.SubElement(placemark, "description").text = "\n".join(description_parts)
+            ET.SubElement(placemark, "styleUrl").text = f"#gss-{gss_value}"
+            _append_geometry(placemark, row.geometry)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    xml_bytes = ET.tostring(kml, encoding="utf-8")
+    pretty = minidom.parseString(xml_bytes).toprettyxml(indent="  ")
+    path.write_text(pretty, encoding="utf-8")
+    LOGGER.info("Wrote %s", path)
+
+
+def _append_geometry(parent: ET.Element, geometry) -> None:
+    if geometry.is_empty:
+        return
+    geom_type = geometry.geom_type
+    if geom_type == "Polygon":
+        _append_polygon(parent, geometry)
+    elif geom_type == "MultiPolygon":
+        multi = ET.SubElement(parent, "MultiGeometry")
+        for geom in geometry.geoms:
+            _append_polygon(multi, geom)
+    else:
+        # Fallback to centroid representation for unexpected geometries
+        point = geometry.centroid
+        point_elem = ET.SubElement(parent, "Point")
+        ET.SubElement(point_elem, "coordinates").text = _coords_to_string(point.coords)
+
+
+def _append_polygon(parent: ET.Element, polygon) -> None:
+    poly_elem = ET.SubElement(parent, "Polygon")
+    outer = ET.SubElement(poly_elem, "outerBoundaryIs")
+    outer_ring = ET.SubElement(outer, "LinearRing")
+    ET.SubElement(outer_ring, "coordinates").text = _coords_to_string(polygon.exterior.coords)
+    for interior in polygon.interiors:
+        inner = ET.SubElement(poly_elem, "innerBoundaryIs")
+        inner_ring = ET.SubElement(inner, "LinearRing")
+        ET.SubElement(inner_ring, "coordinates").text = _coords_to_string(interior.coords)
+
+
+def _coords_to_string(coords) -> str:
+    return " ".join(f"{x:.6f},{y:.6f},0" for x, y, *_ in coords)
+
+
+def _hex_to_kml_color(hex_color: str, alpha: float) -> str:
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        raise ValueError("Hex colors must be 6 digits")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    a = max(0, min(255, int(round(alpha * 255))))
+    return f"{a:02x}{b:02x}{g:02x}{r:02x}"
 
 
 def _write_leaflet_page(path: Path, web_cfg: Dict[str, Any]) -> None:
@@ -242,6 +377,20 @@ def _write_leaflet_page(path: Path, web_cfg: Dict[str, Any]) -> None:
     with path.open("w", encoding="utf-8") as f:
         f.write(html)
     LOGGER.info("Wrote %s", path)
+
+
+def _write_empty_outputs(geojson_path: Path, kml_path: Path) -> None:
+    empty = gpd.GeoDataFrame(geometry=[], crs=4326)
+    _ensure_directory(geojson_path.parent)
+    _write_geojson(empty, geojson_path)
+    _write_kml(empty, kml_path)
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError(f"Dates must be YYYY-MM-DD strings: {value}") from exc
 
 
 if __name__ == "__main__":

--- a/src/storm_filter.py
+++ b/src/storm_filter.py
@@ -1,0 +1,129 @@
+"""Utilities to filter storm-day events before running the change pipeline."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Sequence
+
+import geopandas as gpd
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CatalogSchema:
+    """Column mapping for a tabular storm-event catalog."""
+
+    datetime_column: str = "event_time_utc"
+    hazard_column: str = "hazard"
+    latitude_column: str = "latitude"
+    longitude_column: str = "longitude"
+
+
+def load_catalog(path: Path, schema: CatalogSchema) -> gpd.GeoDataFrame:
+    """Load a CSV catalog of storm events into a GeoDataFrame."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Storm catalog not found: {path}")
+
+    df = pd.read_csv(path)
+    for column in [
+        schema.datetime_column,
+        schema.latitude_column,
+        schema.longitude_column,
+    ]:
+        if column not in df.columns:
+            raise ValueError(f"Storm catalog missing required column '{column}'")
+
+    dt = pd.to_datetime(df[schema.datetime_column], errors="coerce", utc=True)
+    if dt.isna().all():
+        raise ValueError(
+            "Failed to parse storm catalog datetimes; check the datetime column format"
+        )
+
+    df = df.copy()
+    df["event_time_utc"] = dt
+    df["event_date"] = df["event_time_utc"].dt.date
+
+    hazard_values = df.get(schema.hazard_column, None)
+    if hazard_values is not None:
+        df["hazard"] = hazard_values.astype(str)
+    else:
+        df["hazard"] = "Unknown"
+
+    geometry = gpd.points_from_xy(
+        df[schema.longitude_column], df[schema.latitude_column], crs="EPSG:4326"
+    )
+    gdf = gpd.GeoDataFrame(df, geometry=geometry)
+    return gdf
+
+
+def relevant_events(
+    *,
+    catalog: gpd.GeoDataFrame,
+    aoi: gpd.GeoDataFrame,
+    window_start: date,
+    window_end: date,
+    hazards: Sequence[str] | None,
+    days_before: int,
+    days_after: int,
+    distance_km: float,
+) -> gpd.GeoDataFrame:
+    """Return events inside the AOI (optionally buffered) and date window."""
+
+    if catalog.empty:
+        return catalog.iloc[0:0].copy()
+
+    if hazards:
+        normalized_hazards = [h.upper() for h in hazards]
+        mask_hazard = catalog["hazard"].str.upper().isin(normalized_hazards)
+    else:
+        mask_hazard = pd.Series(True, index=catalog.index)
+
+    start_date = window_start - timedelta(days=max(days_before, 0))
+    end_date = window_end + timedelta(days=max(days_after, 0))
+
+    mask_date = catalog["event_date"].between(start_date, end_date)
+    filtered = catalog.loc[mask_hazard & mask_date].copy()
+    if filtered.empty:
+        return filtered
+
+    aoi_geom = _buffer_aoi(aoi, distance_km)
+    mask_geom = filtered.geometry.within(aoi_geom)
+    return filtered.loc[mask_geom].reset_index(drop=True)
+
+
+def _buffer_aoi(aoi: gpd.GeoDataFrame, distance_km: float):
+    """Return the AOI geometry buffered by ``distance_km`` (in kilometers)."""
+
+    if aoi.crs is None:
+        aoi = aoi.set_crs(4326)
+    aoi_wgs84 = aoi.to_crs(4326)
+    geom = aoi_wgs84.unary_union
+    if distance_km <= 0:
+        return geom
+
+    buffer_series = gpd.GeoSeries([geom], crs=4326).to_crs(3857)
+    buffered = buffer_series.buffer(distance_km * 1000.0)
+    return buffered.to_crs(4326).iloc[0]
+
+
+def export_events(events: gpd.GeoDataFrame, path: Path) -> None:
+    """Write relevant storm events to GeoJSON for downstream inspection."""
+
+    if events.empty:
+        collection = {"type": "FeatureCollection", "features": []}
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(collection))
+        LOGGER.info("Wrote empty storm-event log to %s", path)
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if events.crs is None:
+        events = events.set_crs(4326)
+    events.to_crs(4326).to_file(path, driver="GeoJSON")
+    LOGGER.info("Wrote %s storm events to %s", len(events), path)


### PR DESCRIPTION
## Summary
- add a configurable storm-day filter that checks a CSV catalog before running the Sentinel change pipeline
- export qualifying storm events to GeoJSON and emit a Google Earth KML alongside the existing GeoJSON output
- document the new workflow, provide a sample storm report catalog, and add an AWS Batch deployment walkthrough with container assets

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e44cd3d5b4832194c3afc2582da560