### PR TITLE
Document scoring outputs and surface metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The Leaflet app is designed to live under `docs/`. A GitHub Actions workflow (`.
 
 If you prefer to publish the map manually, run the pipeline locally, commit the updated `docs/` folder, and serve it with GitHub Pages or any static hosting provider.
 
+### Scoring metadata export
+
+Every pipeline execution now writes a machine-readable scoring summary to `docs/data/scoring.json`. The file captures the component weights, the resolved change-score threshold, the five Ground-Scour Score breakpoints, and polygon statistics (counts, area, mean-score range). The GitHub Actions workflow publishes this file alongside the Leaflet app, so the repository always documents the scoring system used for the latest run. If you customise the configuration, rerun the pipeline to regenerate the scoring metadata before committing.
+
 ## Tuning tips
 - Tighten the pre/post acquisition windows around the event to avoid seasonal noise.
 - Increase the SAR weight and enable `use_sentinel1_grd` for debris detection over bare ground or low vegetation.

--- a/docs/data/scoring.json
+++ b/docs/data/scoring.json
@@ -1,0 +1,45 @@
+{
+  "generated_at": null,
+  "scoring": {
+    "components": {
+      "d_ndvi": {
+        "label": "Vegetation loss (ΔNDVI)",
+        "weight": 0.6,
+        "active": true
+      },
+      "d_brightness": {
+        "label": "Brightness increase",
+        "weight": 0.3,
+        "active": true
+      },
+      "s1_logratio": {
+        "label": "Sentinel-1 GRD log-ratio magnitude",
+        "weight": 0.1,
+        "active": false
+      }
+    },
+    "sentinel1_enabled": false
+  },
+  "threshold": {
+    "method": null,
+    "value": null
+  },
+  "gss": {
+    "breaks_config": "quantile",
+    "resolved_thresholds": [],
+    "counts": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "5": 0
+    }
+  },
+  "polygons": {
+    "count": 0,
+    "mean_score_min": null,
+    "mean_score_max": null,
+    "total_area_m2": null
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,14 @@
     <h1>Ground Scour Map</h1>
     <p>Auto-built from Sentinel pre/post windows.</p>
   </header>
-  <div id="map"></div>
-  <div id="legend"></div>
+  <main>
+    <div id="map"></div>
+    <div id="legend"></div>
+    <section id="scoring-doc" class="panel">
+      <h2>Scoring Overview</h2>
+      <p class="loading">Loading scoring metadata…</p>
+    </section>
+  </main>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha512-o9N1j7kG6r0s+P0LlwM651op01qmPvvrLpzjAU6Rz6U02zszbmWzxubUANkqG0x74pJ1gzhS+M4LMEnM08JdKw==" crossorigin=""></script>
   <script>
     const map = L.map('map').setView([-27.0, 151.5], 9);
@@ -65,6 +71,96 @@
         legend.appendChild(row);
       }
     }
+
+    function renderScoring(metadata) {
+      const container = document.getElementById('scoring-doc');
+      if (!metadata || !metadata.scoring) {
+        container.innerHTML = '<h2>Scoring Overview</h2><p>Scoring metadata not available.</p>';
+        return;
+      }
+
+      const generated = metadata.generated_at
+        ? new Date(metadata.generated_at).toLocaleString()
+        : 'Unknown';
+
+      const components = metadata.scoring.components || {};
+      const componentItems = Object.entries(components)
+        .map(([key, info]) => {
+          const label = info.label || key;
+          const weight = typeof info.weight === 'number' ? info.weight.toFixed(2) : 'n/a';
+          const status = info.active === false ? ' (inactive)' : '';
+          return `<li><strong>${label}</strong> — weight ${weight}${status}</li>`;
+        })
+        .join('');
+
+      const sentinelComponent = components['s1_logratio'] || {};
+      const sentinel1Status = sentinelComponent.active
+        ? 'Sentinel-1 weighting is enabled.'
+        : 'Sentinel-1 weighting is disabled.';
+
+      const thresholds = metadata.gss?.resolved_thresholds || [];
+      const thresholdList = thresholds
+        .map((value, idx) => `<li>Break ${idx + 1}: ${value.toFixed(3)}</li>`)
+        .join('');
+
+      const gssCounts = metadata.gss?.counts || {};
+      const countRows = Object.entries(gssCounts)
+        .map(([level, count]) => `<tr><th>GSS ${level}</th><td>${count}</td></tr>`)
+        .join('');
+
+      const meanMin = metadata.polygons?.mean_score_min;
+      const meanMax = metadata.polygons?.mean_score_max;
+      const meanRangeText =
+        meanMin != null && meanMax != null
+          ? `${Number(meanMin).toFixed(3)} – ${Number(meanMax).toFixed(3)}`
+          : 'n/a';
+
+      const totalArea = metadata.polygons?.total_area_m2;
+      const totalAreaText =
+        typeof totalArea === 'number'
+          ? `${(totalArea / 1e6).toFixed(2)} km²`
+          : 'n/a';
+
+      container.innerHTML = `
+        <h2>Scoring Overview</h2>
+        <p class="timestamp">Generated ${generated}</p>
+        <section>
+          <h3>Components</h3>
+          <ul class="bullets">${componentItems || '<li>No components reported.</li>'}</ul>
+          <p class="note">${sentinel1Status}</p>
+        </section>
+        <section>
+          <h3>Thresholding</h3>
+          <p>Method: <strong>${metadata.threshold?.method || 'n/a'}</strong>${
+            metadata.threshold?.value != null
+              ? ` (cutoff ${Number(metadata.threshold.value).toFixed(3)})`
+              : ''
+          }</p>
+        </section>
+        <section>
+          <h3>Ground-Scour Score breaks</h3>
+          <ul class="bullets">${thresholdList || '<li>No thresholds reported.</li>'}</ul>
+          <table class="counts">
+            <caption>Polygon counts by GSS</caption>
+            <tbody>${countRows}</tbody>
+          </table>
+        </section>
+        <section>
+          <h3>Polygon summary</h3>
+          <p>Total polygons: <strong>${metadata.polygons?.count ?? 0}</strong></p>
+          <p>Total mapped area: <strong>${totalAreaText}</strong></p>
+          <p>Mean score range: <strong>${meanRangeText}</strong></p>
+        </section>
+      `;
+    }
+
+    fetch('data/scoring.json')
+      .then(resp => resp.json())
+      .then(renderScoring)
+      .catch(() => {
+        const container = document.getElementById('scoring-doc');
+        container.innerHTML = '<h2>Scoring Overview</h2><p>Scoring metadata not available.</p>';
+      });
   </script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -11,9 +11,17 @@ header {
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 
+main {
+  padding: 0 2rem 2.5rem;
+  margin-top: 1.5rem;
+}
+
 #map {
-  height: calc(100vh - 200px);
-  min-height: 400px;
+  height: calc(100vh - 260px);
+  min-height: 420px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.2);
 }
 
 #legend {
@@ -24,6 +32,62 @@ header {
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.panel {
+  margin-top: 2rem;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.panel section {
+  margin-bottom: 1.25rem;
+}
+
+.panel section:last-child {
+  margin-bottom: 0;
+}
+
+.panel .timestamp {
+  color: #5c6c80;
+  font-size: 0.9rem;
+}
+
+.panel .bullets {
+  padding-left: 1.2rem;
+}
+
+.panel .note {
+  color: #51606f;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.panel .counts {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.panel .counts th,
+.panel .counts td {
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid #e3e9f0;
+}
+
+.panel .counts caption {
+  text-align: left;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 .legend-row {


### PR DESCRIPTION
## Summary
- export the scoring configuration and polygon stats as docs/data/scoring.json during each pipeline run
- surface the scoring summary in the published map alongside refreshed styling and seed metadata
- document the automated scoring export and add helpers for reusable threshold and GSS break calculations

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e46428600c8321bcecca42d21dd608