### PR TITLE
Write storm events GeoJSON without Fiona

### DIFF
--- a/src/storm_filter.py
+++ b/src/storm_filter.py
@@ -157,7 +157,9 @@ def export_events(events: gpd.GeoDataFrame, path: Path) -> None:
     if events.crs is None:
         events = events.set_crs(4326)
     events = _stringify_event_fields(events)
-    events.to_crs(4326).to_file(path, driver="GeoJSON")
+    events_wgs84 = events.to_crs(4326)
+    geojson = events_wgs84.to_json()
+    path.write_text(geojson, encoding="utf-8")
     LOGGER.info("Wrote %s storm events to %s", len(events), path)
 
 


### PR DESCRIPTION
## Summary
- write storm filter event exports using GeoDataFrame.to_json instead of to_file to avoid requiring Fiona
- ensure output directory is still created and encoded as UTF-8 JSON text

## Testing
- python -m src.run_pipeline --config data/config.yaml *(fails: STAC catalog blocked by proxy; verified graceful handling up to download step)*

------
https://chatgpt.com/codex/tasks/task_e_68e47d479164832191f1e4cdc77b76c1