### PR TITLE
Add configure step before GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
             docs/data/storm_events.geojson
           if-no-files-found: warn
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- add the recommended configure-pages step before uploading the Pages artifact so deployments can be created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e4acc7c08321bc7999afd73b1551