### PR TITLE
Fix Leaflet fetch error message template

### DIFF
--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -547,7 +547,7 @@ def _write_leaflet_page(path: Path, web_cfg: Dict[str, Any]) -> None:
     fetch('data/changes.geojson')
       .then(resp => {{
         if (!resp.ok) {{
-          throw new Error(`Failed to fetch changes.geojson: ${resp.status}`);
+          throw new Error(`Failed to fetch changes.geojson: ${{resp.status}}`);
         }}
         return resp.json();
       }})


### PR DESCRIPTION
## Summary
- escape the Leaflet error message template literal so Python does not try to interpolate `resp`

## Testing
- python -m compileall src/run_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ed0c456483218e27a951fd759b48