### PR TITLE
Add storm event overlay fallback to map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,8 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha512-o9N1j7kG6r0s+P0LlwM651op01qmPvvrLpzjAU6Rz6U02zszbmWzxubUANkqG0x74pJ1gzhS+M4LMEnM08JdKw==" crossorigin=""></script>
   <script>
     const map = L.map('map').setView([-27.0, 151.5], 9);
+    let combinedBounds = null;
+    let stormEventCount = 0;
 
     const australianBasemap = L.tileLayer(
       'https://services.ga.gov.au/gis/rest/services/NationalMap_Colour_Topography/MapServer/tile/{z}/{y}/{x}',
@@ -109,7 +111,11 @@
         }
         clearEmptyState();
         const layer = L.geoJSON(data, { style }).addTo(map);
-        map.fitBounds(layer.getBounds());
+        const bounds = layer.getBounds();
+        if (bounds.isValid()) {
+          combinedBounds = L.latLngBounds(bounds);
+          map.fitBounds(combinedBounds.pad(0.05));
+        }
         buildLegend();
       })
       .catch(err => {
@@ -127,7 +133,85 @@
         row.innerHTML = `<span class="swatch" style="background:${colors[i]}"></span> GSS ${i}`;
         legend.appendChild(row);
       }
+      if (stormEventCount > 0) {
+        const divider = document.createElement('hr');
+        divider.className = 'legend-divider';
+        legend.appendChild(divider);
+
+        const stormRow = document.createElement('div');
+        stormRow.className = 'legend-row legend-row--storms';
+        stormRow.innerHTML = `
+          <span class="storm-marker"></span>
+          Storm reports (${stormEventCount})
+        `;
+        legend.appendChild(stormRow);
+      }
     }
+
+    function fitToBounds(newBounds) {
+      if (!newBounds || !newBounds.isValid()) return;
+      if (combinedBounds) {
+        combinedBounds.extend(newBounds);
+      } else {
+        combinedBounds = L.latLngBounds(newBounds);
+      }
+      map.fitBounds(combinedBounds.pad(0.1));
+    }
+
+    fetch('data/storm_events.geojson')
+      .then(resp => {
+        if (!resp.ok) {
+          throw new Error(`Failed to fetch storm_events.geojson: ${resp.status}`);
+        }
+        return resp.json();
+      })
+      .then(data => {
+        const features = Array.isArray(data.features) ? data.features : [];
+        if (!features.length) {
+          return;
+        }
+
+        stormEventCount = features.length;
+        const layer = L.geoJSON(data, {
+          pointToLayer: (_feature, latlng) =>
+            L.circleMarker(latlng, {
+              radius: 6,
+              fillColor: '#f94144',
+              color: '#a4161a',
+              weight: 1,
+              opacity: 1,
+              fillOpacity: 0.85
+            }),
+          onEachFeature: (feature, layer) => {
+            const props = feature.properties || {};
+            const title = props.hazard || 'Storm report';
+            const details = props.details ? `<p>${props.details}</p>` : '';
+            const timestamp = props.event_time_utc
+              ? new Date(props.event_time_utc).toLocaleString()
+              : null;
+            layer.bindPopup(`
+              <strong>${title}</strong>
+              ${timestamp ? `<p>${timestamp}</p>` : ''}
+              ${details}
+            `);
+          }
+        }).addTo(map);
+
+        const bounds = layer.getBounds();
+        fitToBounds(bounds);
+        const banner = document.querySelector('#map .map-empty');
+        if (banner && !banner.dataset.stormContext) {
+          banner.dataset.stormContext = 'true';
+          banner.insertAdjacentHTML(
+            'beforeend',
+            '<p class="map-empty-note">Recent storm reports are highlighted in red.</p>'
+          );
+        }
+        buildLegend();
+      })
+      .catch(err => {
+        console.warn('Storm events layer unavailable', err);
+      });
 
     function renderScoring(metadata) {
       const container = document.getElementById('scoring-doc');

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -40,6 +40,14 @@ main {
   color: #354052;
 }
 
+#map .map-empty .map-empty-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  font-weight: 500;
+  color: #5c6c80;
+}
+
 #legend {
   position: absolute;
   bottom: 20px;
@@ -48,6 +56,12 @@ main {
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+#legend .legend-divider {
+  border: none;
+  border-top: 1px solid rgba(31, 45, 61, 0.15);
+  margin: 0.75rem 0;
 }
 
 .panel {
@@ -122,5 +136,18 @@ main {
   width: 18px;
   height: 18px;
   border: 1px solid #444;
+  display: inline-block;
+}
+
+.legend-row--storms {
+  font-weight: 600;
+}
+
+.storm-marker {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f94144, #f3722c);
+  border: 1px solid #a4161a;
   display: inline-block;
 }


### PR DESCRIPTION
## Summary
- show storm report markers on the Leaflet map when change polygons are unavailable
- keep the map view fitting to whichever datasets are present and note storm markers in the legend
- style the legend and empty-state banner to highlight the additional context

## Testing
- python -m http.server --directory docs 8000

------
https://chatgpt.com/codex/tasks/task_e_68e5a2cc969483218bb718d8defa21fc