### PR TITLE
Add demo change polygons for GitHub Pages map

### DIFF
--- a/docs/data/changes.geojson
+++ b/docs/data/changes.geojson
@@ -1,0 +1,74 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 1,
+        "mean_score": 0.72,
+        "max_score": 0.91,
+        "gss": 3,
+        "bearing_deg": 210.0,
+        "elongation_ratio": 2.6
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [151.38, -27.21],
+            [151.43, -27.21],
+            [151.43, -27.16],
+            [151.38, -27.16],
+            [151.38, -27.21]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 2,
+        "mean_score": 0.54,
+        "max_score": 0.67,
+        "gss": 2,
+        "bearing_deg": 205.0,
+        "elongation_ratio": 1.9
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [151.47, -27.25],
+            [151.53, -27.25],
+            [151.53, -27.19],
+            [151.47, -27.19],
+            [151.47, -27.25]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 3,
+        "mean_score": 0.31,
+        "max_score": 0.44,
+        "gss": 1,
+        "bearing_deg": 195.0,
+        "elongation_ratio": 1.6
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [151.32, -27.18],
+            [151.36, -27.18],
+            [151.36, -27.14],
+            [151.32, -27.14],
+            [151.32, -27.18]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/docs/data/scoring.json
+++ b/docs/data/scoring.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": null,
+  "generated_at": "2024-01-12T00:00:00Z",
   "scoring": {
     "components": {
       "d_ndvi": {
@@ -21,25 +21,31 @@
     "sentinel1_enabled": false
   },
   "threshold": {
-    "method": null,
-    "value": null
+    "method": "otsu",
+    "value": 0.37
   },
   "gss": {
     "breaks_config": "quantile",
-    "resolved_thresholds": [],
+    "resolved_thresholds": [
+      0.25,
+      0.4,
+      0.55,
+      0.7,
+      0.85
+    ],
     "counts": {
       "0": 0,
-      "1": 0,
-      "2": 0,
-      "3": 0,
+      "1": 1,
+      "2": 1,
+      "3": 1,
       "4": 0,
       "5": 0
     }
   },
   "polygons": {
-    "count": 0,
-    "mean_score_min": null,
-    "mean_score_max": null,
-    "total_area_m2": null
+    "count": 3,
+    "mean_score_min": 0.31,
+    "mean_score_max": 0.72,
+    "total_area_m2": 648000.0
   }
 }


### PR DESCRIPTION
## Summary
- add a sample `changes.geojson` so the GitHub Pages Leaflet map renders polygon data out of the box
- align the published scoring metadata with the bundled demo features so the sidebar shows representative counts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d24d39b083218fb03076e4d597c3