### PR TITLE
Add labeled storm event tooltips to map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -194,6 +194,27 @@
               ${timestamp ? `<p>${timestamp}</p>` : ''}
               ${details}
             `);
+
+            const labelParts = [];
+            if (props.hazard) {
+              labelParts.push(props.hazard);
+            }
+            if (props.event_time_utc) {
+              const timeString = new Date(props.event_time_utc).toLocaleString();
+              labelParts.push(timeString);
+            }
+            if (props.details) {
+              labelParts.push(props.details);
+            }
+
+            if (labelParts.length) {
+              layer.bindTooltip(labelParts.join(' • '), {
+                permanent: true,
+                direction: 'top',
+                offset: [0, -10],
+                className: 'storm-tooltip'
+              });
+            }
           }
         }).addTo(map);
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -151,3 +151,19 @@ main {
   border: 1px solid #a4161a;
   display: inline-block;
 }
+
+.leaflet-tooltip.storm-tooltip {
+  background: rgba(255, 255, 255, 0.92);
+  color: #1f2d3d;
+  border: 1px solid rgba(164, 22, 26, 0.6);
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.35rem 0.55rem;
+  text-align: center;
+}
+
+.leaflet-tooltip-top.storm-tooltip::before {
+  border-top-color: rgba(164, 22, 26, 0.6);
+}


### PR DESCRIPTION
## Summary
- add permanent tooltips to storm event markers that describe the hazard, time, and details
- style storm event tooltips to keep them readable against the basemap

## Testing
- python -m http.server --directory docs 8000


------
https://chatgpt.com/codex/tasks/task_e_68e5da0efe908321a244e2944d81fd41