### PR TITLE
Default web map to global basemap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,10 +101,12 @@
       attribution: '&copy; OpenStreetMap contributors'
     });
 
-    australianBasemap.addTo(map);
+    osmBasemap.addTo(map);
 
     australianBasemap.on('tileerror', () => {
-      map.removeLayer(australianBasemap);
+      if (map.hasLayer(australianBasemap)) {
+        map.removeLayer(australianBasemap);
+      }
       if (!map.hasLayer(osmBasemap)) {
         osmBasemap.addTo(map);
       }
@@ -112,8 +114,8 @@
 
     L.control.layers(
       {
-        'Australian Topography': australianBasemap,
-        'OpenStreetMap': osmBasemap
+        'OpenStreetMap': osmBasemap,
+        'Australian Topography': australianBasemap
       },
       null,
       { position: 'topright' }


### PR DESCRIPTION
## Summary
- default the interactive map to OpenStreetMap tiles so global events render correctly
- retain the Australian topographic layer as an optional base map and harden its tile error fallback

## Testing
- python -m http.server 8000 --directory docs

------
https://chatgpt.com/codex/tasks/task_e_68e5f9d96dd48321b03dc608e46d4537