### PR TITLE
Update stackstac usage for bounds handling

### DIFF
--- a/src/stac_fetch.py
+++ b/src/stac_fetch.py
@@ -127,8 +127,7 @@ def _stack_items(
         resolution=DEFAULT_RESOLUTION,
         epsg=target_epsg,
         bounds=bounds_projected,
-        bounds_crs=f"EPSG:{target_epsg}",
-        chunks={},
+        chunksize=1024,
         fill_value=np.nan,
     )
     stack = stack.where(np.isfinite(stack))


### PR DESCRIPTION
## Summary
- adjust stackstac stack call to use current parameters and drop unsupported bounds_crs
- set chunksize explicitly for stacking

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f882b71ec83219ba6a79307692336)